### PR TITLE
Prevent query string parameters to be altered by providing a custom parse_str method.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "psr/log": "^1.1.1 || ^1.1.0"
   },
   "require-dev": {
-    "drupol/php-conventions": "^1.7.0",
+    "drupol/php-conventions": "^1.7.1",
     "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
     "infection/infection": "^0.12.2 || ^0.13.6 || ^0.14.4 || ^0.15.0",
     "monolog/monolog": "^1.0",

--- a/spec/EcPhp/CasLib/Utils/UriSpec.php
+++ b/spec/EcPhp/CasLib/Utils/UriSpec.php
@@ -11,6 +11,13 @@ class UriSpec extends ObjectBehavior
 {
     public function it_can_check_if_some_query_parameters_exists()
     {
+        $url = 'http://host/path';
+
+        $uri = new \Nyholm\Psr7\Uri($url);
+
+        $this::hasParams($uri, 'param1')
+            ->shouldReturn(false);
+
         $url = 'http://host/path?param1=param1&param2=param2#fragment';
 
         $uri = new \Nyholm\Psr7\Uri($url);
@@ -29,6 +36,19 @@ class UriSpec extends ObjectBehavior
 
         $this::hasParams($uri, 'param1', 'param2', 'param3')
             ->shouldReturn(false);
+    }
+
+    public function it_can_check_uri_with_parameters_containing_dots()
+    {
+        $url = 'http://host/path?param.withdot=foo';
+
+        $uri = new \Nyholm\Psr7\Uri($url);
+
+        $this::hasParams($uri, 'param.withdot')
+            ->shouldReturn(true);
+
+        $this::getParam($uri, 'param.withdot')
+            ->shouldReturn('foo');
     }
 
     public function it_can_create_a_new_uri_with_a_new_param()


### PR DESCRIPTION
This PR

* [x] Has new tests
* [x] Provide a custom parse_str() method.
* [x] Is backward compatible 

Fixes #5.
