### PR TITLE
Remove obsolete libxml calls.

### DIFF
--- a/src/Introspection/Introspector.php
+++ b/src/Introspection/Introspector.php
@@ -87,9 +87,6 @@ final class Introspector implements IntrospectorInterface
         }
 
         if ('XML' === $format) {
-            libxml_disable_entity_loader(true);
-            libxml_use_internal_errors(true);
-
             try {
                 $dom = new DOMDocument();
 


### PR DESCRIPTION
This PR

* [x] Remove obsolete `libxml_*` calls.

Fixes #15 
