### PR TITLE
ECPHP-152: Do not update `service` parameter

### DIFF
--- a/spec/EcPhp/CasLib/CasSpec.php
+++ b/spec/EcPhp/CasLib/CasSpec.php
@@ -1000,7 +1000,7 @@ EOF;
             ->withServerRequest($request)
             ->login($parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/login?renew=true&service=http%3A%2F%2Flocal%2F%3Frenew%3D0']);
+            ->shouldReturn(['http://local/cas/login?renew=true&service=http%3A%2F%2Flocal%2F']);
 
         $request = new ServerRequest('GET', $from . '?renew=false');
 

--- a/spec/EcPhp/CasLib/Redirect/LoginSpec.php
+++ b/spec/EcPhp/CasLib/Redirect/LoginSpec.php
@@ -64,7 +64,7 @@ class LoginSpec extends ObjectBehavior
                     'parameters' => [
                         'renew' => true,
                         'gateway' => true,
-                        'service' => 'service?gateway=0&renew=0',
+                        'service' => 'service',
                     ],
                     'validatedParameters' => null,
                 ]
@@ -93,7 +93,7 @@ class LoginSpec extends ObjectBehavior
             ->debug(
                 'Building service response redirection to {url}.',
                 [
-                    'url' => 'http://local/cas/login?renew=true&service=http%3A%2F%2Fapp%3Frenew%3D0',
+                    'url' => 'http://local/cas/login?renew=true&service=http%3A%2F%2Fapp',
                 ]
             )
             ->shouldHaveBeenCalledOnce();

--- a/src/Redirect/Login.php
+++ b/src/Redirect/Login.php
@@ -46,7 +46,6 @@ final class Login extends Redirect implements RedirectInterface
     protected function formatProtocolParameters(array $parameters): array
     {
         $parameters = parent::formatProtocolParameters($parameters);
-        $parametersToSetToZero = [];
 
         foreach (['gateway', 'renew'] as $queryParameter) {
             if (false === array_key_exists($queryParameter, $parameters)) {
@@ -54,17 +53,6 @@ final class Login extends Redirect implements RedirectInterface
             }
 
             $parameters[$queryParameter] = 'true';
-            $parametersToSetToZero[] = $queryParameter;
-        }
-
-        if (true === array_key_exists('service', $parameters)) {
-            $service = $this->getUriFactory()->createUri($parameters['service']);
-
-            foreach ($parametersToSetToZero as $parameterToSetToZero) {
-                $service = Uri::withParam($service, $parameterToSetToZero, '0');
-            }
-
-            $parameters['service'] = (string) $service;
         }
 
         return $parameters;


### PR DESCRIPTION
This PR

* [x] Make sure to not alter the `service` parameter with the `renew` and `gateway` parameters.
* [x] Update tests accordingly. 

Internal ticket: ECPHP-152