### PR TITLE
Suppress the PHP 8+ deprecation message that pops when APP_DEBUG=true

### DIFF
--- a/src/Configuration/Properties.php
+++ b/src/Configuration/Properties.php
@@ -47,6 +47,7 @@ final class Properties implements PropertiesInterface
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->properties);
@@ -57,6 +58,7 @@ final class Properties implements PropertiesInterface
      *
      * @return array<string, mixed>|string|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->properties[$offset];


### PR DESCRIPTION
This PR

* [x] Suppress the PHP 8+ deprecation message that pops when APP_DEBUG=true

For PHP <8 projects, the attribute `#[\ReturnTypeWillChange]` will be ignored as it starts with a `#`. 

Adding this attribute allows using the bundle with PHP 8+ (without that annoying deprecation message) without breaking the compatibility with lower PHP versions.