### PR TITLE
fix: make sure handlers `parameters` are correctly handled

### DIFF
--- a/spec/EcPhp/CasLib/CasSpec.php
+++ b/spec/EcPhp/CasLib/CasSpec.php
@@ -435,15 +435,6 @@ class CasSpec extends ObjectBehavior
 
         $request = new ServerRequest(
             Method::GET,
-            'http://local/proxycallback?pgtId=pgtId&pgtIou=false'
-        );
-
-        $this
-            ->shouldThrow(Exception::class)
-            ->during('handleProxyCallback', [$request]);
-
-        $request = new ServerRequest(
-            Method::GET,
             'http://local/proxycallback?pgtId=pgtId'
         );
 
@@ -509,7 +500,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->login($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/login?foo=bar&service=http%3A%2F%2Flocal%2F%3Ffoo%3Dbar']);
+            ->shouldReturn(['http://local/cas/login?foo=bar&service=http%3A%2F%2Ffoo.bar%2F']);
 
         $parameters = [
             'custom' => 'foo',
@@ -518,7 +509,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->login($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/login?custom=foo&service=http%3A%2F%2Flocal%2F%3Fcustom%3Dfoo']);
+            ->shouldReturn(['http://local/cas/login?custom=foo&service=http%3A%2F%2Flocal%2F']);
 
         $request = new ServerRequest(Method::GET, 'http://local/', ['referer' => 'http://referer/']);
 
@@ -530,7 +521,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->login($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/login?foo=bar&service=http%3A%2F%2Flocal%2F%3Ffoo%3Dbar']);
+            ->shouldReturn(['http://local/cas/login?foo=bar&service=http%3A%2F%2Ffoo.bar%2F']);
 
         $parameters = [
             'custom' => 'foo',
@@ -539,7 +530,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->login($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/login?custom=foo&service=http%3A%2F%2Flocal%2F%3Fcustom%3Dfoo']);
+            ->shouldReturn(['http://local/cas/login?custom=foo&service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'foo',
@@ -549,7 +540,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->login($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/login?custom=foo&service=http%3A%2F%2Flocal%2F%3Fcustom%3Dfoo']);
+            ->shouldReturn(['http://local/cas/login?custom=foo']);
     }
 
     public function it_can_logout()
@@ -568,7 +559,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->logout($request)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/logout']);
+            ->shouldReturn(['http://local/cas/logout?service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'bar',
@@ -577,7 +568,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->logout($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/logout?custom=bar']);
+            ->shouldReturn(['http://local/cas/logout?custom=bar&service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'bar',
@@ -598,7 +589,7 @@ class CasSpec extends ObjectBehavior
         $this
             ->logout($request, $parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/logout?custom=bar']);
+            ->shouldReturn(['http://local/cas/logout?custom=bar&service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'bar',
@@ -915,10 +906,6 @@ class CasSpec extends ObjectBehavior
         $cacheItemPgtIou
             ->get()
             ->willReturn('pgtIou');
-
-        $cache
-            ->getItem('false')
-            ->willThrow(Exception::class);
 
         $cache
             ->hasItem('unknownPgtIou')

--- a/spec/EcPhp/CasLib/Handler/LoginSpec.php
+++ b/spec/EcPhp/CasLib/Handler/LoginSpec.php
@@ -17,7 +17,7 @@ use Ergebnis\Http\Method;
 use Exception;
 use loophp\psr17\Psr17;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Request;
 use Nyholm\Psr7\Uri;
 use PhpSpec\ObjectBehavior;
 use Psr\Cache\CacheItemPoolInterface;
@@ -45,7 +45,7 @@ class LoginSpec extends ObjectBehavior
             $psr17
         );
 
-        $request = new ServerRequest(
+        $request = new Request(
             Method::GET,
             new Uri('http://from/it_can_deal_with_array_parameters')
         );
@@ -57,7 +57,7 @@ class LoginSpec extends ObjectBehavior
         $this
             ->handle($request)
             ->getHeaderLine('Location')
-            ->shouldReturn('http://local/cas/login?custom%5B0%5D=1&custom%5B1%5D=2&custom%5B2%5D=3&custom%5B3%5D=4&custom%5B4%5D=5&service=http%3A%2F%2Ffrom%2Fit_can_deal_with_array_parameters%3Fcustom%255B0%255D%3D1%26custom%255B1%255D%3D2%26custom%255B2%255D%3D3%26custom%255B3%255D%3D4%26custom%255B4%255D%3D5');
+            ->shouldReturn('http://local/cas/login?custom%5B0%5D=1&custom%5B1%5D=2&custom%5B2%5D=3&custom%5B3%5D=4&custom%5B4%5D=5&service=http%3A%2F%2Ffrom%2Fit_can_deal_with_array_parameters');
     }
 
     public function it_can_deal_with_renew_and_gateway_parameters(CacheItemPoolInterface $cache, CasResponseBuilderInterface $casResponseBuilder)
@@ -80,7 +80,7 @@ class LoginSpec extends ObjectBehavior
             $psr17
         );
 
-        $request = new ServerRequest(
+        $request = new Request(
             Method::GET,
             new Uri('http://from/it_can_deal_with_renew_and_gateway_parameters')
         );
@@ -109,7 +109,7 @@ class LoginSpec extends ObjectBehavior
             $psr17
         );
 
-        $request = new ServerRequest(
+        $request = new Request(
             Method::GET,
             new Uri('http://from/it_can_deal_with_renew_parameter')
         );
@@ -121,7 +121,7 @@ class LoginSpec extends ObjectBehavior
 
     public function it_can_get_a_response()
     {
-        $request = new ServerRequest(
+        $request = new Request(
             Method::GET,
             new Uri('http://from/it_can_deal_with_renew_parameter')
         );

--- a/src/Handler/Login.php
+++ b/src/Handler/Login.php
@@ -24,25 +24,11 @@ final class Login extends Handler implements HandlerInterface
 {
     public function handle(RequestInterface $request): ResponseInterface
     {
-        $parameters = $this->getParameters();
-        $parameters += Uri::getParams($request->getUri());
-
-        // Add the query parameter to the service.
-        // Investigate if this is really needed.
-        // We do it here before adding the default parameters.
-        $parameters['service'] = (string) Uri::withParams(
-            $request->getUri(),
-            array_diff_key(
-                $parameters,
-                [
-                    'service' => null,
-                    'renew' => null,
-                ]
-            )
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $this->getProperties()['protocol'][HandlerInterface::TYPE_LOGIN]['default_parameters'] ?? [],
+            ['service' => (string) $request->getUri()],
         );
-
-        $parameters += $this->getProperties()['protocol'][HandlerInterface::TYPE_LOGIN]['default_parameters'] ?? [];
-        $parameters = $this->formatProtocolParameters($parameters);
 
         $this->validate($request, $parameters);
 

--- a/src/Handler/Logout.php
+++ b/src/Handler/Logout.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace EcPhp\CasLib\Handler;
 
 use EcPhp\CasLib\Contract\Handler\HandlerInterface;
-use EcPhp\CasLib\Utils\Uri;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -20,9 +19,11 @@ final class Logout extends Handler implements HandlerInterface
 {
     public function handle(RequestInterface $request): ResponseInterface
     {
-        $parameters = $this->getParameters();
-        $parameters += Uri::getParams($request->getUri());
-        $parameters += $this->getProperties()['protocol'][HandlerInterface::TYPE_LOGOUT]['default_parameters'] ?? [];
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $this->getProperties()['protocol'][HandlerInterface::TYPE_LOGOUT]['default_parameters'] ?? [],
+            ['service' => (string) $request->getUri()],
+        );
 
         return $this
             ->getPsr17()
@@ -33,7 +34,7 @@ final class Logout extends Handler implements HandlerInterface
                     ->buildUri(
                         $request->getUri(),
                         HandlerInterface::TYPE_LOGOUT,
-                        $this->formatProtocolParameters($parameters)
+                        $parameters
                     )
             );
     }

--- a/src/Handler/Proxy.php
+++ b/src/Handler/Proxy.php
@@ -13,7 +13,6 @@ namespace EcPhp\CasLib\Handler;
 
 use EcPhp\CasLib\Contract\Handler\HandlerInterface;
 use EcPhp\CasLib\Exception\CasHandlerException;
-use EcPhp\CasLib\Utils\Uri;
 use Ergebnis\Http\Method;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,12 +22,11 @@ final class Proxy extends Handler implements HandlerInterface
 {
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $properties = $this->getProperties();
-
-        $parameters = $this->getParameters();
-        $parameters += Uri::getParams($request->getUri());
-        $parameters += $properties['protocol'][HandlerInterface::TYPE_PROXY]['default_parameters'] ?? [];
-        $parameters += ['service' => (string) $request->getUri()];
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $this->getProperties()['protocol'][HandlerInterface::TYPE_PROXY]['default_parameters'] ?? [],
+            ['service' => (string) $request->getUri()],
+        );
 
         $request = $this
             ->getPsr17()
@@ -38,7 +36,7 @@ final class Proxy extends Handler implements HandlerInterface
                     ->buildUri(
                         $request->getUri(),
                         HandlerInterface::TYPE_PROXY,
-                        $this->formatProtocolParameters($parameters)
+                        $parameters
                     )
             );
 

--- a/src/Handler/ServiceValidate.php
+++ b/src/Handler/ServiceValidate.php
@@ -16,7 +16,6 @@ use EcPhp\CasLib\Contract\Handler\ServiceValidateHandlerInterface;
 use EcPhp\CasLib\Contract\Response\Type\AuthenticationFailure;
 use EcPhp\CasLib\Contract\Response\Type\ServiceValidate as TypeServiceValidate;
 use EcPhp\CasLib\Exception\CasHandlerException;
-use EcPhp\CasLib\Utils\Uri;
 use Ergebnis\Http\Method;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,10 +33,11 @@ final class ServiceValidate extends Handler implements ServiceValidateHandlerInt
             ? HandlerInterface::TYPE_PROXY_VALIDATE
             : HandlerInterface::TYPE_SERVICE_VALIDATE;
 
-        $parameters = $this->getParameters();
-        $parameters += Uri::getParams($request->getUri());
-        $parameters += $properties['protocol'][$type]['default_parameters'] ?? [];
-        $parameters += ['service' => (string) $request->getUri()];
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $properties['protocol'][$type]['default_parameters'] ?? [],
+            ['service' => (string) $request->getUri()],
+        );
 
         $request = $this
             ->getPsr17()
@@ -47,7 +47,7 @@ final class ServiceValidate extends Handler implements ServiceValidateHandlerInt
                     ->buildUri(
                         $request->getUri(),
                         $type,
-                        $this->formatProtocolParameters($parameters)
+                        $parameters
                     )
             );
 


### PR DESCRIPTION
This PR

- [x] Make sure that handler `parameters`  can be overridden properly, it was not the case before because the precedence mechanism was ignoring those.

