### PR TITLE
Backport - fix: make sure handlers `parameters` are correctly handled

### DIFF
--- a/spec/EcPhp/CasLib/CasSpec.php
+++ b/spec/EcPhp/CasLib/CasSpec.php
@@ -850,7 +850,7 @@ class CasSpec extends ObjectBehavior
             ->withServerRequest($request)
             ->logout()
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/logout']);
+            ->shouldReturn(['http://local/cas/logout?service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'bar',
@@ -860,7 +860,7 @@ class CasSpec extends ObjectBehavior
             ->withServerRequest($request)
             ->logout($parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/logout?custom=bar']);
+            ->shouldReturn(['http://local/cas/logout?custom=bar&service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'bar',
@@ -883,7 +883,7 @@ class CasSpec extends ObjectBehavior
             ->withServerRequest($request)
             ->logout($parameters)
             ->getHeader('Location')
-            ->shouldReturn(['http://local/cas/logout?custom=bar']);
+            ->shouldReturn(['http://local/cas/logout?custom=bar&service=http%3A%2F%2Flocal%2F']);
 
         $parameters = [
             'custom' => 'bar',

--- a/src/Handler/Handler.php
+++ b/src/Handler/Handler.php
@@ -65,6 +65,29 @@ abstract class Handler
     }
 
     /**
+     * This function will aggregate all the input arrays into a single array.
+     *
+     * The rule of concatenation is that the previous array will have precedence
+     * over the current array.
+     *
+     * Therefore: buildParameters([a=>1], [a=>2,b=>3]) will return [a=>1, b=>3]
+     *
+     * @param array<array-key, mixed> ...$parameters
+     *
+     * @return array<array-key, mixed>
+     */
+    protected function buildParameters(array ...$parameters): array
+    {
+        return $this->formatProtocolParameters(
+            array_reduce(
+                $parameters,
+                static fn (array $carry, array $item): array => $carry + $item,
+                []
+            )
+        );
+    }
+
+    /**
      * @param mixed[]|string[]|UriInterface[] $query
      */
     protected function buildUri(UriInterface $from, string $name, array $query = []): UriInterface
@@ -158,7 +181,7 @@ abstract class Handler
 
     protected function getParameters(): array
     {
-        return $this->parameters + ($this->getProtocolProperties()['default_parameters'] ?? []);
+        return $this->parameters;
     }
 
     protected function getProperties(): PropertiesInterface

--- a/src/Redirect/Login.php
+++ b/src/Redirect/Login.php
@@ -21,7 +21,12 @@ final class Login extends Redirect implements RedirectInterface
 {
     public function handle(): ?ResponseInterface
     {
-        $parameters = $this->formatProtocolParameters($this->getParameters());
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $this->getProtocolProperties()['default_parameters'] ?? [],
+            ['service' => (string) $this->getServerRequest()->getUri()],
+        );
+        $parameters = $this->formatProtocolParameters($parameters);
         $validatedParameters = $this->validate($parameters);
 
         if (null === $validatedParameters) {
@@ -58,13 +63,7 @@ final class Login extends Redirect implements RedirectInterface
 
     protected function getProtocolProperties(): array
     {
-        $protocolProperties = $this->getProperties()['protocol']['login'] ?? [];
-
-        $protocolProperties['default_parameters'] += [
-            'service' => (string) $this->getServerRequest()->getUri(),
-        ];
-
-        return $protocolProperties;
+        return $this->getProperties()['protocol']['login'] ?? [];
     }
 
     /**

--- a/src/Redirect/Logout.php
+++ b/src/Redirect/Logout.php
@@ -29,7 +29,12 @@ final class Logout extends Redirect implements RedirectInterface
     private function getUri(): UriInterface
     {
         $serverRequest = $this->getServerRequest()->getUri();
-        $parameters = $this->formatProtocolParameters($this->getParameters());
+
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $this->getProtocolProperties()['default_parameters'] ?? [],
+            ['service' => (string) $serverRequest],
+        );
 
         return $this->buildUri($serverRequest, 'logout', $parameters);
     }

--- a/src/Service/Proxy.php
+++ b/src/Service/Proxy.php
@@ -43,10 +43,15 @@ final class Proxy extends Service implements ServiceInterface
 
     protected function getUri(): UriInterface
     {
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            $this->getProtocolProperties()['default_parameters'] ?? []
+        );
+
         return $this->buildUri(
             $this->getServerRequest()->getUri(),
             'proxy',
-            $this->formatProtocolParameters($this->getParameters())
+            $parameters
         );
     }
 }

--- a/src/Service/ProxyValidate.php
+++ b/src/Service/ProxyValidate.php
@@ -18,22 +18,24 @@ final class ProxyValidate extends Service implements ServiceInterface
 {
     protected function getProtocolProperties(): array
     {
-        $protocolProperties = $this->getProperties()['protocol']['proxyValidate'] ?? [];
-
-        $protocolProperties['default_parameters'] += [
-            'service' => (string) $this->getServerRequest()->getUri(),
-            'ticket' => Uri::getParam($this->getServerRequest()->getUri(), 'ticket'),
-        ];
-
-        return $protocolProperties;
+        return $this->getProperties()['protocol']['proxyValidate'] ?? [];
     }
 
     protected function getUri(): UriInterface
     {
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            [
+                'service' => (string) $this->getServerRequest()->getUri(),
+                'ticket' => Uri::getParam($this->getServerRequest()->getUri(), 'ticket'),
+            ],
+            $this->getProtocolProperties()['default_parameters'] ?? []
+        );
+
         return $this->buildUri(
             $this->getServerRequest()->getUri(),
             'proxyValidate',
-            $this->formatProtocolParameters($this->getParameters())
+            $parameters
         );
     }
 }

--- a/src/Service/ServiceValidate.php
+++ b/src/Service/ServiceValidate.php
@@ -18,22 +18,24 @@ final class ServiceValidate extends Service implements ServiceInterface
 {
     protected function getProtocolProperties(): array
     {
-        $protocolProperties = $this->getProperties()['protocol']['serviceValidate'] ?? [];
-
-        $protocolProperties['default_parameters'] += [
-            'service' => (string) $this->getServerRequest()->getUri(),
-            'ticket' => Uri::getParam($this->getServerRequest()->getUri(), 'ticket'),
-        ];
-
-        return $protocolProperties;
+        return $this->getProperties()['protocol']['serviceValidate'] ?? [];
     }
 
     protected function getUri(): UriInterface
     {
+        $parameters = $this->buildParameters(
+            $this->getParameters(),
+            [
+                'service' => (string) $this->getServerRequest()->getUri(),
+                'ticket' => Uri::getParam($this->getServerRequest()->getUri(), 'ticket'),
+            ],
+            $this->getProtocolProperties()['default_parameters'] ?? []
+        );
+
         return $this->buildUri(
             $this->getServerRequest()->getUri(),
             'serviceValidate',
-            $this->formatProtocolParameters($this->getParameters())
+            $parameters
         );
     }
 }


### PR DESCRIPTION
This PR

- [x] Make sure that handler `parameters`  can be overridden properly, it was not the case before because the precedence mechanism was ignoring those.