### PR TITLE
refactor: use `POST` instead of `GET` in service validation

### DIFF
--- a/src/Handler/ServiceValidate.php
+++ b/src/Handler/ServiceValidate.php
@@ -16,7 +16,6 @@ use EcPhp\CasLib\Contract\Handler\ServiceValidateHandlerInterface;
 use EcPhp\CasLib\Contract\Response\Type\AuthenticationFailure;
 use EcPhp\CasLib\Contract\Response\Type\ServiceValidate as TypeServiceValidate;
 use EcPhp\CasLib\Exception\CasHandlerException;
-use EcPhp\CasLib\Utils\Uri;
 use Ergebnis\Http\Method;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Handler/ServiceValidate.php
+++ b/src/Handler/ServiceValidate.php
@@ -16,6 +16,7 @@ use EcPhp\CasLib\Contract\Handler\ServiceValidateHandlerInterface;
 use EcPhp\CasLib\Contract\Response\Type\AuthenticationFailure;
 use EcPhp\CasLib\Contract\Response\Type\ServiceValidate as TypeServiceValidate;
 use EcPhp\CasLib\Exception\CasHandlerException;
+use EcPhp\CasLib\Utils\Uri;
 use Ergebnis\Http\Method;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -40,13 +41,16 @@ final class ServiceValidate extends Handler implements ServiceValidateHandlerInt
         $request = $this
             ->getPsr17()
             ->createRequest(
-                Method::GET,
+                Method::POST,
                 $this
                     ->buildUri(
                         $request->getUri(),
-                        $type,
-                        $parameters
+                        $type
                     )
+                    ->withQuery('')
+            )
+            ->withBody(
+                $this->getPsr17()->createStream(http_build_query($parameters))
             );
 
         try {


### PR DESCRIPTION
This PR

- [x]
- [ ]
- [ ]

Follows #. Related to #. Fixes #.
